### PR TITLE
dropping nans in columns and then rows

### DIFF
--- a/interactive/api/controller.py
+++ b/interactive/api/controller.py
@@ -55,7 +55,8 @@ def get_configuration_as_json(file_path):
                 path = [f for f in files if rates_file in f]
                 if len(path) > 0:
                     rates_file = path[0]
-                    df = pd.read_csv(rates_file)
+                    # drop blank columns and then blank rows
+                    df = pd.read_csv(rates_file).dropna(axis=1, how='all').dropna(axis=0, how='all')
                     conditions["initial conditions"] = df.to_dict()
                     del df
                 else:
@@ -70,7 +71,8 @@ def get_configuration_as_json(file_path):
                     path = [f for f in files if evolving_conditions in f]
                     if len(path) > 0:
                         evolving_conditions = path[0]
-                        df = pd.read_csv(evolving_conditions)
+                        # drop blank columns and then blank rows
+                        df = pd.read_csv(evolving_conditions).dropna(axis=1, how='all').dropna(axis=0, how='all')
                         conditions["evolving conditions"] = df.to_dict()
                         del df
                     else:


### PR DESCRIPTION
Any evolving conditions files that had empty columns or empty rows would return data to the client that contained `nan` which is not parseable by json. This drops empty columns and then empty rows since evolving conditions files should never have NaNs