### PR TITLE
Fix docker dependencies

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -15,7 +15,7 @@ services:
       - /etc/pki/:/certificates
       # - partmc-data:/music-box-interactive/interactive/partmc-volume
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/manage/health"]
+      test: ["CMD", "curl", "-f", "--insecure", "https://localhost:8000/manage/health"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -43,7 +43,6 @@ services:
     volumes:
       # - partmc-data:/partmc/partmc-volume
       - db-data:/music-box-interactive/interactive
-    network_mode: "host"
     logging:
       driver: "json-file"
       options:

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -14,6 +14,11 @@ services:
       - db-data:/music-box-interactive/interactive
       - /etc/pki/:/certificates
       # - partmc-data:/music-box-interactive/interactive/partmc-volume
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/manage/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
     network_mode: "host"
     restart: on-failure
     logging:
@@ -31,6 +36,10 @@ services:
     deploy:
       mode: replicated
       replicas: 6
+    command: ["poetry", "run", "python3", "/music-box-interactive/interactive/rabbit_mq_model_runner.py"]
+    depends_on:
+      api-server:
+        condition: service_healthy
     volumes:
       # - partmc-data:/partmc/partmc-volume
       - db-data:/music-box-interactive/interactive

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,8 +52,8 @@ services:
       - ~/.docker-conf/rabbitmq/log/:/var/log/rabbitmq
     healthcheck:
       test: rabbitmq-diagnostics -q ping
-      interval: 5s
-      timeout: 15s
+      interval: 10s
+      timeout: 30s
       retries: 10
 volumes:
   db-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,11 @@ services:
     volumes:
       - db-data:/music-box-interactive/interactive
       - partmc-data:/music-box-interactive/interactive/partmc-volume
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/manage/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
   model-runner:
     build: 
       context: .
@@ -24,11 +29,15 @@ services:
     env_file:
       - ./.env
     depends_on:
-      - rabbitmq
+      rabbitmq:
+        condition: service_healthy
+      api-server:
+        condition: service_healthy
     restart: on-failure
     deploy:
       mode: replicated
       replicas: 6
+    command: ["poetry", "run", "python3", "/music-box-interactive/interactive/rabbit_mq_model_runner.py"]
     volumes:
       - partmc-data:/partmc/partmc-volume
       - db-data:/music-box-interactive/interactive

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       test: rabbitmq-diagnostics -q ping
       interval: 10s
       timeout: 30s
-      retries: 10
+      retries: 30
 volumes:
   db-data:
   partmc-data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,7 +54,7 @@ services:
       test: rabbitmq-diagnostics -q ping
       interval: 5s
       timeout: 15s
-      retries: 1
+      retries: 10
 volumes:
   db-data:
   partmc-data:

--- a/docker/Dockerfile.model_runner
+++ b/docker/Dockerfile.model_runner
@@ -21,7 +21,7 @@ RUN dnf -y update \
 
 RUN pip3 install poetry
 
-COPY . /music-box-interactive/
+COPY ./pyproject.toml /music-box-interactive/pyproject.toml 
 WORKDIR /music-box-interactive
 
 # Configure Poetry to create virtual environments in the project directory
@@ -31,5 +31,3 @@ ENV CXXFLAGS="-Wno-error=redundant-move"
 RUN if [ "$INSTALL_PyPartMC" = "true" ]; then poetry install --all-extras; else poetry install -E music_box; fi
 
 RUN mkdir -p /partmc/partmc-volume
-
-CMD ["poetry", "run", "python3", "/music-box-interactive/interactive/rabbit_mq_model_runner.py"]

--- a/interactive/rabbit_mq_model_runner.py
+++ b/interactive/rabbit_mq_model_runner.py
@@ -161,6 +161,7 @@ def run_music_box(session_id):
 
     music_box.create_solver(campConfig)
 
+    logging.info(f"Submitting job to thread pool for session {session_id}")
     future = pool.submit(music_box.solve, os.path.join(working_directory, "output.csv"))
     future.add_done_callback(
         functools.partial(
@@ -169,6 +170,7 @@ def run_music_box(session_id):
             working_directory
         )
     )
+    logging.info("Job submitted to thread pool")
 
     set_model_run_status(session_id, RunStatus.RUNNING.value)
 

--- a/interactive/rabbit_mq_model_runner.py
+++ b/interactive/rabbit_mq_model_runner.py
@@ -162,6 +162,7 @@ def run_music_box(session_id):
     music_box.create_solver(campConfig)
 
     logging.info(f"Submitting job to thread pool for session {session_id}")
+    set_model_run_status(session_id, RunStatus.RUNNING.value)
     future = pool.submit(music_box.solve, os.path.join(working_directory, "output.csv"))
     future.add_done_callback(
         functools.partial(
@@ -170,9 +171,6 @@ def run_music_box(session_id):
             working_directory
         )
     )
-    logging.info("Job submitted to thread pool")
-
-    set_model_run_status(session_id, RunStatus.RUNNING.value)
 
 
 def run_partmc(session_id):


### PR DESCRIPTION
- Saves the model running status to the database first
  - Otherwise, it often takes some time from the model running to the status update, I guess because of the GIL
- Adds a health check command to the api server so we can tell when it's up and running
- The model runner only starts after the api server
  - It also only copies the file it needs to install its dependencies
  - These two things seem to remove the need for us to manually update the database

However, I did learn that sqlite forces concurrent access, so many people starting simulations will cause delays because each model runner needs to access the database. I think we need to fully decouple the runner from the api server in some way